### PR TITLE
Use File.join(__dir__, ...) instead of hardcoding the filepath for the wordlist

### DIFF
--- a/lazys3.rb
+++ b/lazys3.rb
@@ -94,7 +94,7 @@ class Wordlist
   end
 end
 
-wordlist = Wordlist.from_file(ARGV[0], 'common_bucket_prefixes.txt')
+wordlist = Wordlist.from_file(ARGV[0], File.join(__dir__, 'common_bucket_prefixes.txt'))
 
 puts "Generated wordlist from file, #{wordlist.length} items..."
 


### PR DESCRIPTION
We couldn't symlink the script in another path to run it from anywhere because the path of the wordlist would be considered relative to where we run the script. So, this PR solves this issue by using introducing the wordlist path as the absolute path where the script is contained. So, the script can be run from anywhere just by symlinking the script to any directory in PATH.
For example.
```bash
sudo ln -s $HOME/lazys3/lazys3.rb -T /usr/bin/lazys3
```